### PR TITLE
Make using SDL 2.0.14 RawInput configurable on instantiation

### DIFF
--- a/src/main/java/com/studiohartman/jamepad/Configuration.java
+++ b/src/main/java/com/studiohartman/jamepad/Configuration.java
@@ -1,0 +1,19 @@
+package com.studiohartman.jamepad;
+
+/**
+ * Class defining the configuration of a {@link ControllerManager}.
+ *
+ * @author Benjamin Schulte
+ */
+public class Configuration {
+    /**
+     * The max number of controllers the ControllerManager should deal with
+     */
+    public int maxNumControllers = 4;
+
+    /**
+     * Use RawInput implementation instead of XInput on Windows, if applicable. Enable this if you
+     * need to use more than four XInput controllers at once. Comes with drawbacks.
+     */
+    public boolean useRawInput = false;
+}


### PR DESCRIPTION
You can now configure whether RawInput is used on Windows for XInput devices. 

Introduced a new `Configuration` class, allowing us to add further configuration properties without breaking method compatibility in the future. 