### PR TITLE
add config option to skip shared library loader

### DIFF
--- a/src/main/java/com/studiohartman/jamepad/Configuration.java
+++ b/src/main/java/com/studiohartman/jamepad/Configuration.java
@@ -16,4 +16,10 @@ public class Configuration {
      * need to use more than four XInput controllers at once. Comes with drawbacks.
      */
     public boolean useRawInput = false;
+
+    /**
+     * Disable this to skip loading of the native library. Can be useful if an application wants
+     * to use a loader other than {@link com.badlogic.gdx.utils.SharedLibraryLoader}.
+     */
+    public boolean loadNativeLibrary = true;
 }

--- a/src/main/java/com/studiohartman/jamepad/ControllerManager.java
+++ b/src/main/java/com/studiohartman/jamepad/ControllerManager.java
@@ -63,7 +63,9 @@ public class ControllerManager {
         isInitialized = false;
         controllers = new ControllerIndex[configuration.maxNumControllers];
 
-        new SharedLibraryLoader().load("jamepad");
+        if (configuration.loadNativeLibrary) {
+            new SharedLibraryLoader().load("jamepad");
+        }
     }
 
     /**


### PR DESCRIPTION
Use case: for Windows builds of our game, we ship all shared libraries in a separate `./bin` folder and load them upfront, using explicit calls to LWJGL3's `Library.loadSystem()` function. This avoids a bunch of tedious bugs & issues regarding custom user install paths, but needs the option to skip the "extract-from-jar-and-load" calls later.