### PR TITLE
Allow configuration option to load db from memory instead of tmp file.

### DIFF
--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -49,7 +49,7 @@ jobs:
 
   linux:
     needs: macos
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""
       ORG_GRADLE_PROJECT_GITHUB_API_TOKEN: ""

--- a/src/main/java/com/studiohartman/jamepad/Configuration.java
+++ b/src/main/java/com/studiohartman/jamepad/Configuration.java
@@ -22,4 +22,9 @@ public class Configuration {
      * to use a loader other than {@link com.badlogic.gdx.utils.SharedLibraryLoader}.
      */
     public boolean loadNativeLibrary = true;
+
+    /**
+     * Disable this to return to legacy temporary file loading of database file.
+     */
+    public boolean loadDatabaseInMemory = true;
 }


### PR DESCRIPTION
I don't like using ByteArrayOutputStream since it requires resizing + copying during toByteArray() but I don't see a better option to read (or even just get file length to optimize) from classpath in java7 without external dependencies.

Tested and works on linux64.