### PR TITLE
Changes necessary for gdx-controllers Desktop hotplugging changes.

### DIFF
--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -56,7 +56,7 @@ jobs:
 
   linux:
     needs: macos
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""
       ORG_GRADLE_PROJECT_GITHUB_API_TOKEN: ""

--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Install Windows compilers
       run: sudo apt-get -yq install g++-mingw-w64-i686 g++-mingw-w64-x86-64
     - name: Install Linux x86 compilers/libraries
-      run: sudo apt-get -yq install gcc-multilib g++-multilib linux-libc-dev:i386 libstdc++-5-dev:i386
+      run: sudo apt-get -yq install gcc-multilib g++-multilib linux-libc-dev:i386
     - name: Install Linux arm32 compilers/libraries
       run: sudo apt-get -yq install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
     - name: Install Linux arm64 compilers/libraries

--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -55,7 +55,7 @@ jobs:
 
   linux:
     needs: macos
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""
       ORG_GRADLE_PROJECT_GITHUB_API_TOKEN: ""

--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Install Windows compilers
       run: sudo apt-get -yq install g++-mingw-w64-i686 g++-mingw-w64-x86-64
     - name: Install Linux x86 compilers/libraries
-      run: sudo apt-get -yq install gcc-multilib g++-multilib linux-libc-dev:i386 libstdc++-5-dev:i386
+      run: sudo apt-get -yq install gcc-multilib g++-multilib linux-libc-dev:i386
     - name: Install Linux arm32 compilers/libraries
       run: sudo apt-get -yq install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
     - name: Install Linux arm64 compilers/libraries

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.badlogicgames.jamepad
-version=2.24.0.0
+version=2.26.4.0
 POM_DESCRIPTION=libGDX jamepad build
 POM_NAME=libGDX jamepad build
 POM_URL=https://github.com/libgdx/jamepad

--- a/src/main/java/com/studiohartman/jamepad/ControllerIndex.java
+++ b/src/main/java/com/studiohartman/jamepad/ControllerIndex.java
@@ -268,6 +268,23 @@ public final class ControllerIndex {
     */
 
     /**
+     * Returns the instance ID of the current controller, which uniquely identifies
+     * the device from the time it is connected until it is disconnected.
+     *
+     * @return The instance ID of the current controller
+     * @throws ControllerUnpluggedException If the controller is not connected
+     */
+    public int getDeviceInstanceID() throws ControllerUnpluggedException {
+        ensureConnected();
+        return nativeGetDeviceInstanceID(controllerPtr);
+    }
+
+    private native int nativeGetDeviceInstanceID(long controllerPtr); /*
+        SDL_Joystick* joystick = SDL_GameControllerGetJoystick((SDL_GameController*) controllerPtr);
+        return SDL_JoystickInstanceID(joystick);
+     */
+
+    /**
      * @return player index if set and supported, -1 otherwise
      */
     public int getPlayerIndex() throws ControllerUnpluggedException {

--- a/src/main/java/com/studiohartman/jamepad/ControllerManager.java
+++ b/src/main/java/com/studiohartman/jamepad/ControllerManager.java
@@ -249,15 +249,18 @@ public class ControllerManager {
      *
      * If there hasn't been a change in whether controller are connected or not, nothing will happen.
      *
+     * @return True if the controller list was refreshed, false otherwise
      * @throws IllegalStateException if Jamepad was not initialized
      */
-    public void update() {
+    public boolean update() {
         verifyInitialized();
         if (nativeControllerConnectedOrDisconnected()) {
             for (int i = 0; i < controllers.length; i++) {
                 controllers[i].reconnectController();
             }
+            return true;
         }
+        return false;
     }
     private native boolean nativeControllerConnectedOrDisconnected(); /*
         SDL_JoystickUpdate();


### PR DESCRIPTION
Preparation for a fix to libgdx/gdx-controllers#29

Adds ControllerIndex#getDeviceInstanceID() to return the SDL instance ID, which uniquely identifies the controller while connected.
This is the necessary change of this PR. It gives us access to the information we need to track controllers properly.

ControllerManager#update() now returns a boolean that identifies if the controller list changed as a result of the call.
This change is more optional, but I think it will allow us to improve performance. Instead of having to manually verify that the controller list is correct each frame, we can use this to detect when Jamepad updates its list, so we can update ours in response.

Updates SDL to 2.26.4. Updates version number to match.