### PR TITLE
Updates Github actions to version 3.

### DIFF
--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -12,10 +12,10 @@ jobs:
   macos:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -23,10 +23,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
 
     - run: mkdir -p SDL/build-macosarm64
     # No --disable-video for macOS https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c70c727c98b24ad8b44e05285b8785be15062af0
@@ -49,7 +50,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew jnigen jnigenBuild
     - name: Upload macOS natives
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v3
       with:
         name: macos-natives
         path: libs
@@ -61,10 +62,10 @@ jobs:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""
       ORG_GRADLE_PROJECT_GITHUB_API_TOKEN: ""
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -72,10 +73,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
 
     - run: sudo sed -i 's/deb http/deb [arch=amd64,i386] http/' /etc/apt/sources.list
     - run: sudo grep "ubuntu.com/ubuntu" /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
@@ -93,7 +95,7 @@ jobs:
     - name: Install Linux arm64 compilers/libraries
       run: sudo apt-get -yq install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
     - name: Download macOS natives
-      uses: actions/download-artifact@v2.0.5
+      uses: actions/download-artifact@v3
       with:
         name: macos-natives
         path: libs
@@ -143,7 +145,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew jnigen jnigenBuild jnigenJarNativesDesktop
     - name: Upload all output libs
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v3
       with:
         name: output-libs
         path: build/libs/

--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -11,10 +11,10 @@ jobs:
   macos:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -22,10 +22,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
 
     - run: mkdir -p SDL/build-macosarm64
     # No --disable-video for macOS https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c70c727c98b24ad8b44e05285b8785be15062af0
@@ -48,7 +49,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew jnigen jnigenBuild
     - name: Upload macOS natives
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v3
       with:
         name: macos-natives
         path: libs
@@ -60,10 +61,10 @@ jobs:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""
       ORG_GRADLE_PROJECT_GITHUB_API_TOKEN: ""
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -71,10 +72,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
 
     - run: sudo sed -i 's/deb http/deb [arch=amd64,i386] http/' /etc/apt/sources.list
     - run: sudo grep "ubuntu.com/ubuntu" /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
@@ -92,7 +94,7 @@ jobs:
     - name: Install Linux arm64 compilers/libraries
       run: sudo apt-get -yq install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
     - name: Download macOS natives
-      uses: actions/download-artifact@v2.0.5
+      uses: actions/download-artifact@v3
       with:
         name: macos-natives
         path: libs
@@ -142,7 +144,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew jnigen jnigenBuild jnigenJarNativesDesktop
     - name: Upload all output libs
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v3
       with:
         name: output-libs
         path: build/libs/


### PR DESCRIPTION
The @v1 and @v2 actions use Node12, which is deprecated and scheduled for removal.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/