### PR TITLE
Update import-gpg to v5 in release workflow

### DIFF
--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -150,9 +150,9 @@ jobs:
         path: build/libs/
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@v3
+      uses: crazy-max/ghaction-import-gpg@v5
       with:
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
     - name: Release build deploy
       env:


### PR DESCRIPTION
v3 uses deprecated features.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I'm not able to properly test this change as it is related to releasing.