### PR TITLE
ci: Use macos-latest runner like libgdx

### DIFF
--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
macos-11 isn't around anymore @MrStahlfelge 