### PR TITLE
Fix GitHub Actions workflows failing due to using glibc 2.17

### DIFF
--- a/.github/workflows/pushaction.yml
+++ b/.github/workflows/pushaction.yml
@@ -3,6 +3,9 @@ name: Compile and deploy snapshot artifacts
 on: [push, pull_request] # Don't worry, the actual deployment is guarded with an "if" and only done on push to master
 env:
   GRADLE_USER_HOME: .gradle
+  # Needed in order to use Node 16. Node 20 does not work with glibc 2.17
+  # See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   macos:

--- a/.github/workflows/releaseaction.yml
+++ b/.github/workflows/releaseaction.yml
@@ -6,6 +6,9 @@ on:
 
 env:
   GRADLE_USER_HOME: .gradle
+  # Needed in order to use Node 16. Node 20 does not work with glibc 2.17
+  # See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   macos:


### PR DESCRIPTION
PR #23 (#0774bd6) added a container setup to build with glibc 2.17. Unfortunately, GitHub recently started forcing actions to run on Node 20 instead of Node 16 (https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/). Node 20 does not work with glibc 2.17 and using it results in the build failing.

This PR temporarily fixes build issues by using the environment variable mentioned on the aforementioned page. We will need a longer term solution soon however, as once download-artifact@v3 and upload-artifact@v3 are deprecated, we will be forced to use v4 which require Node 20.

Tested working: https://github.com/SonicGDX/Jamepad/actions/runs/11374736859

See https://github.com/libgdx/Jamepad/pull/23 for the full discussion.